### PR TITLE
refactor:entity -> responseDTO 생성자로 변경

### DIFF
--- a/src/main/java/geulsam/archive/domain/book/controller/BookController.java
+++ b/src/main/java/geulsam/archive/domain/book/controller/BookController.java
@@ -3,14 +3,15 @@ package geulsam.archive.domain.book.controller;
 import geulsam.archive.domain.book.dto.res.BookIdRes;
 import geulsam.archive.domain.book.dto.res.BookRes;
 import geulsam.archive.domain.book.service.BookService;
+import geulsam.archive.global.common.dto.PageRes;
 import geulsam.archive.global.common.dto.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -21,17 +22,21 @@ public class BookController {
 
     private final BookService bookService;
 
-    /**Book Controller
-     * DB에 있는 모든 문집의 정보를 Return
-     * @return List<BookRes>
+    /**
+     * DB 에 있는 book 컬럼을 paging 해서 return
+     * @param page 원하는 페이지 번호
+     * @return PageRes<BookRes>
      */
     @GetMapping()
-    public ResponseEntity<SuccessResponse<List<BookRes>>> book(){
+    public ResponseEntity<SuccessResponse<PageRes<BookRes>>> book(
+            @RequestParam(defaultValue = "1") int page
+    ){
+        Pageable pageable = PageRequest.of(page - 1, 12, Sort.by(Sort.Order.asc("year")));
 
-        List<BookRes> book = bookService.book();
+        PageRes<BookRes> book = bookService.book(pageable);
 
         return ResponseEntity.ok().body(
-                SuccessResponse.<List<BookRes>>builder()
+                SuccessResponse.<PageRes<BookRes>>builder()
                         .data(book)
                         .message("books get success")
                         .status(HttpStatus.OK.value())

--- a/src/main/java/geulsam/archive/domain/book/dto/res/BookIdRes.java
+++ b/src/main/java/geulsam/archive/domain/book/dto/res/BookIdRes.java
@@ -1,6 +1,7 @@
 package geulsam.archive.domain.book.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import geulsam.archive.domain.book.entity.Book;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,18 +11,17 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 M월 d일")
 public class BookIdRes {
     /**BookId Response 객체 인덱스*/
     @Schema(example = "1")
     private String id;
     /**Book 이 공개된 날짜*/
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 M월 d일")
-    @Schema(example = "2024-05-06")
+    @Schema(example = "2024년 5월 6일", type = "string")
     private LocalDate release;
     /**Book 의 Designer*/
     @Schema(example = "김철수")
-    private String Designer;
+    private String designer;
     /**Book 의 판형*/
     @Schema(example = "A4")
     private String plate;
@@ -33,5 +33,19 @@ public class BookIdRes {
     private String url;
     /**Book 의 제목*/
     @Schema(example = "책 제목")
-    private String book;
+    private String title;
+
+    /**
+     * Book 객체를 받아 BookIdRes 로 매핑 
+     * @param book
+     */
+    public BookIdRes(Book book){
+        this.id = book.getId().toString();
+        this.release = book.getRelease();
+        this.designer = book.getDesigner();
+        this.plate = book.getPlate();
+        this.page = book.getPageNumber();
+        this.url = book.getUrl();
+        this.title =book.getTitle();
+    }
 }

--- a/src/main/java/geulsam/archive/domain/book/dto/res/BookRes.java
+++ b/src/main/java/geulsam/archive/domain/book/dto/res/BookRes.java
@@ -1,6 +1,7 @@
 package geulsam.archive.domain.book.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import geulsam.archive.domain.book.entity.Book;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -22,7 +23,7 @@ public class BookRes {
     private String bookCover;
     /**Book 이 제작된 연도*/
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년")
-    @Schema(example = "2021년")
+    @Schema(example = "2021년", type = "string")
     private Year year;
     /**Book 에 대한 설명*/
     @Schema(example = "문집 설명")
@@ -32,9 +33,19 @@ public class BookRes {
     private String bookId;
     /**Book 객체가 저장된 시간*/
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 M월 d일")
-    @Schema(example = "2024-04-11T:12:30:11")
+    @Schema(example = "2024년 4월 11일", type = "string")
     private LocalDateTime createdAt;
     /**Book 객체 재목*/
     @Schema(example = "책 제목")
     private String title;
+
+    public BookRes(Book book, int id){
+        this.id = id;
+        this.bookCover = book.getCoverUrl();
+        this.year = book.getYear();
+        this.description = null;
+        this.bookId = book.getId().toString();
+        this.createdAt = book.getCreatedAt();
+        this.title = book.getTitle();
+    }
 }

--- a/src/main/java/geulsam/archive/domain/book/repository/BookRepository.java
+++ b/src/main/java/geulsam/archive/domain/book/repository/BookRepository.java
@@ -1,6 +1,8 @@
 package geulsam.archive.domain.book.repository;
 
 import geulsam.archive.domain.book.entity.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +13,5 @@ import java.util.UUID;
 public interface BookRepository extends JpaRepository<Book, UUID> {
 
     @Override
-    List<Book> findAll();
+    Page<Book> findAll(Pageable pageable);
 }

--- a/src/main/java/geulsam/archive/domain/poster/controller/PosterController.java
+++ b/src/main/java/geulsam/archive/domain/poster/controller/PosterController.java
@@ -1,24 +1,20 @@
 package geulsam.archive.domain.poster.controller;
 
+import geulsam.archive.global.common.dto.PageRes;
 import geulsam.archive.domain.poster.dto.res.PosterRes;
 import geulsam.archive.domain.poster.service.PosterService;
 import geulsam.archive.global.common.dto.SuccessResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,11 +25,11 @@ public class PosterController {
     private final PosterService posterService;
 
     /**
-     * DB 에 있는 모든 poster 를 return
-     * @return List<PosterRes>
+     * DB 에 있는 poster 컬럼을 paging 해서 return
+     * @return PageRes<PosterRes>
      */
     @GetMapping()
-    public ResponseEntity<SuccessResponse<List<PosterRes>>> poster(
+    public ResponseEntity<SuccessResponse<PageRes<PosterRes>>> poster(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "asc") String order ){ //poster?page=1&order=asc
 
@@ -42,10 +38,11 @@ public class PosterController {
         //pageNumber 는 클라이언트에서 1로 넘어오지만 Spring 의 페이징 기능은 페이지가 0부터 시작
         // pageSize 는 12로 고정, 정렬 기준 속성도 year 로 고정
         Pageable pageable = PageRequest.of(page-1, 12, Sort.by(direction, "year"));
-        List<PosterRes> poster = posterService.poster(pageable);
+//        List<PosterRes> poster = posterService.poster(pageable);
 
+        PageRes<PosterRes> poster = posterService.poster(pageable);
         return ResponseEntity.ok().body(
-                SuccessResponse.<List<PosterRes>>builder()
+                SuccessResponse.<PageRes<PosterRes>>builder()
                         .data(poster)
                         .message("posters get success")
                         .status(HttpStatus.OK.value())

--- a/src/main/java/geulsam/archive/domain/poster/dto/res/PosterRes.java
+++ b/src/main/java/geulsam/archive/domain/poster/dto/res/PosterRes.java
@@ -1,36 +1,50 @@
 package geulsam.archive.domain.poster.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import geulsam.archive.domain.poster.entity.Poster;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.time.Year;
 
 @Getter
 @AllArgsConstructor
-@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 M월 d일")
+@Setter(AccessLevel.PROTECTED)
 public class PosterRes {
     /**posterRes 배열의 index*/
-    @Schema(example = "0")
+    @Schema(description = "페이지 내의 Poster 객체 순서", example = "0")
     private int id;
     /**poster image 저장 주소 url*/
-    @Schema(example = "https://imageURL")
+    @Schema(description = "poster 의 저장 주소", example = "https://imageURL")
     private String image;
     /**thumbnail image 저장 주소 url*/
-    @Schema(example = "https://thumbnailImageURL")
+    @Schema(description = "poster thumbnail 의 저장 주소",example = "https://thumbnailImageURL")
     private String thumbnailImage;
     /**poster 제작자*/
-    @Schema(example = "김철수")
+    @Schema(description = "poster 제작자", example = "김철수")
     private String designer;
     /**poster 제작 연도*/
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년")
-    @Schema(example = "2024")
+    @Schema(description = "poster 가 사용된 연도", example = "2024년", type = "string")
     private Year year;
     /**poster 가 DB에 insert 된 날짜*/
+    @Schema(description = "poster 가 DB 에 insert 된 날짜", example = "2024년 5월 6일", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 M월 d일")
-    @Schema(example = "2024-05-06T09:00:00")
     private LocalDateTime createdAt;
+
+    /**
+     * Poster 객체를 PosterRes 객체로 변환
+     * @param poster
+     * @param id
+     */
+    public PosterRes(Poster poster, int id){
+        this.id = id;
+        this.image = poster.getUrl();
+        this.thumbnailImage = poster.getThumbNailUrl();
+        this.designer = poster.getDesigner();
+        this.year = poster.getYear();
+        this.createdAt = poster.getCreatedAt();
+    }
 }

--- a/src/main/java/geulsam/archive/domain/poster/service/PosterService.java
+++ b/src/main/java/geulsam/archive/domain/poster/service/PosterService.java
@@ -1,5 +1,6 @@
 package geulsam.archive.domain.poster.service;
 
+import geulsam.archive.global.common.dto.PageRes;
 import geulsam.archive.domain.poster.dto.res.PosterRes;
 import geulsam.archive.domain.poster.entity.Poster;
 import geulsam.archive.domain.poster.repository.PosterRepository;
@@ -26,21 +27,17 @@ public class PosterService {
      * @return List
      */
     @Transactional(readOnly = true)
-    public List<PosterRes> poster(Pageable pageable) {
-        List<Poster> posterList = posterRepository.findAll(pageable).getContent();
+    public PageRes<PosterRes> poster(Pageable pageable) {
+        Page<Poster> posterPage = posterRepository.findAll(pageable);
 
         //Poster 객체를 PosterRes 객체로 mapping
-        return IntStream.range(0, posterList.size())
-                .mapToObj(i -> {
-                    Poster poster = posterList.get(i);
-                    return new PosterRes(
-                            i,
-                            poster.getUrl(),
-                            poster.getThumbNailUrl(),
-                            poster.getDesigner(),
-                            poster.getYear(),
-                            poster.getCreatedAt()
-                    );
-                }).collect(Collectors.toList());
+        List<PosterRes> posterResList = posterPage.getContent().stream()
+                .map(poster -> new PosterRes(poster, posterPage.getContent().indexOf(poster)))
+                .collect(Collectors.toList());
+
+        return new PageRes<>(
+                posterPage.getTotalPages(),
+                posterResList
+        );
     }
 }

--- a/src/main/java/geulsam/archive/domain/user/controller/UserController.java
+++ b/src/main/java/geulsam/archive/domain/user/controller/UserController.java
@@ -7,8 +7,6 @@ import geulsam.archive.domain.user.service.UserService;
 import geulsam.archive.global.common.dto.SuccessResponse;
 import geulsam.archive.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -50,7 +48,7 @@ public class UserController {
                 signupReq.getEmail(),
                 signupReq.getJoinedAt(),
                 signupReq.getIntroduce(),
-                signupReq.getKeyword(),
+                String.join(", ", signupReq.getKeyword()), // List<String>을 쉼표로 구분된 단일 String 으로 변경
                 signupReq.getBirthDay()
         );
 

--- a/src/main/java/geulsam/archive/domain/user/dto/req/SignupReq.java
+++ b/src/main/java/geulsam/archive/domain/user/dto/req/SignupReq.java
@@ -2,6 +2,7 @@ package geulsam.archive.domain.user.dto.req;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.Data;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Year;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -44,9 +46,9 @@ public class SignupReq {
     @Schema(example = "자기소개입니다")
     private String introduce;
 
-    @NotBlank
-    @Schema(example = "가나,다라,마바")
-    private String keyword;
+    @NotEmpty // 추후 각각 유효성 검사 필요!
+    @Schema(example = "[\"가나\",\"다라\",\"마바\"]")
+    private List<String> keyword;
 
     @NotNull
     @Schema(example = "2024-05-01")

--- a/src/main/java/geulsam/archive/global/common/dto/PageRes.java
+++ b/src/main/java/geulsam/archive/global/common/dto/PageRes.java
@@ -1,0 +1,16 @@
+package geulsam.archive.global.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageRes<T> {
+    /**총 페이지 수*/
+    @Schema(example = "3")
+    private int pageTotal;
+    private List<T> content;
+}


### PR DESCRIPTION
## 이슈 번호/링크


## 주요 수정사항
entity를 responseDTO로 매핑하는 과정을 responseDTO의 생성자를 통해 실행하도록 변경

## 코드 리뷰 시 중점적으로 볼 부분
- responseDTO의 생성자
- service의 mapping logic
- 나중에 service mapping logic을 전략 패턴을 사용해 바꿀 수 있음
