### PR TITLE
feat:user/check API 추가, 토큰 인증 절차 변경

### DIFF
--- a/src/main/java/geulsam/archive/domain/refreshtoken/entity/RefreshToken.java
+++ b/src/main/java/geulsam/archive/domain/refreshtoken/entity/RefreshToken.java
@@ -1,9 +1,7 @@
 package geulsam.archive.domain.refreshtoken.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import geulsam.archive.domain.user.entity.User;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,12 +15,22 @@ public class RefreshToken {
 
     @Id
     @Column(name = "refreshToken_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
     @Column(name = "refreshToken_value")
     private String token;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     public void changeTokenValue(String token){
         this.token = token;
+    }
+
+    public RefreshToken(String token, User user){
+        this.token = token;
+        this.user = user;
     }
 }

--- a/src/main/java/geulsam/archive/domain/refreshtoken/repository/RefreshTokenRepository.java
+++ b/src/main/java/geulsam/archive/domain/refreshtoken/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package geulsam.archive.domain.refreshtoken.repository;
 
 import geulsam.archive.domain.refreshtoken.entity.RefreshToken;
+import geulsam.archive.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -13,4 +14,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Inte
      * @return
      */
     Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUser(User user);
 }

--- a/src/main/java/geulsam/archive/domain/user/dto/res/CheckRes.java
+++ b/src/main/java/geulsam/archive/domain/user/dto/res/CheckRes.java
@@ -1,0 +1,17 @@
+package geulsam.archive.domain.user.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class CheckRes {
+
+    @Schema(description = "유저 아이디", example = "1")
+    private int id;
+    @Schema(description = "유저 역할 목록", example = "[\"ADMIN\",\"NORMAL\",\"GRADUATED\",\"SUSPENDED\"]")
+    private List<String> roles;
+}

--- a/src/main/java/geulsam/archive/domain/user/dto/res/LoginRes.java
+++ b/src/main/java/geulsam/archive/domain/user/dto/res/LoginRes.java
@@ -9,7 +9,9 @@ import lombok.Data;
 public class LoginRes {
 
     /** accessToken: 사용자 식별에 사용. 유효기간 짧음*/
+    @Schema(description = "accessToken:사용자 식별에 사용 유효기간 짧음", example = "asdfdsa.sadfa.dsafdsa")
     private String AccessToken;
     /** refreshToken: 토큰 재발급에 사용. 유효기간 김*/
+    @Schema(description = "refreshToken: 토큰 재발급에 사용 유효기간 김", example = "sadf.dsafd.asdf")
     private String RefreshToken;
 }

--- a/src/main/java/geulsam/archive/global/security/SecurityConfig.java
+++ b/src/main/java/geulsam/archive/global/security/SecurityConfig.java
@@ -56,6 +56,9 @@ public class SecurityConfig {
                                 // 로그인, 회원가입은 일단 전체 허용 -> 회원가입은 deploy hasRole("master")로 이동
                                 .requestMatchers(HttpMethod.POST,"/user/signup").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/user/login").permitAll()
+                                // 유저 refresh 토큰 받아서 새로운 토큰 생성(초기 로그인)
+                                .requestMatchers(HttpMethod.GET, "/user/refresh").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/user/check").authenticated()
                                 .requestMatchers(HttpMethod.GET, "/poster/**").permitAll()
                                 .requestMatchers(HttpMethod.POST,"/poster").hasRole("NORMAL")
                                 .requestMatchers(HttpMethod.DELETE, "/poster").hasRole("NORMAL")

--- a/src/main/java/geulsam/archive/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/geulsam/archive/global/security/jwt/JwtAuthenticationFilter.java
@@ -16,15 +16,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Objects;
 
 /** jwt 를 사용해서 사용자를 식별하는 필터 */
 @Component
@@ -55,9 +52,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
                 /* accessToken 의 id 를 사용하여 새로운 accessToken 생성 */
-                String id = jwtProvider.getID(accessToken);
-                String newAccessToken = jwtProvider.createAccessToken(Integer.valueOf(id));
-                response.setHeader("accessToken", "Bearer " + newAccessToken);
+//                String id = jwtProvider.getID(accessToken);
+//                String newAccessToken = jwtProvider.createAccessToken(Integer.valueOf(id));
+//                response.setHeader("accessToken", "Bearer " + newAccessToken);
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -69,7 +66,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 /* 새로운 RefreshToken 생성 */
                 String newRefreshToken = jwtProvider.createRefreshToken();
-                String newAccessToken = jwtProvider.createAccessToken(refreshTokenInRepo.getId());
+                String newAccessToken = jwtProvider.createAccessToken(refreshTokenInRepo.getUser().getId());
 
                 /* Refresh 리포지토리를 업데이트 */
                 refreshTokenInRepo.changeTokenValue(newRefreshToken);


### PR DESCRIPTION
## 이슈 번호/링크
https://github.com/geulsamArchive/backend/issues/32

## 주요 수정사항
- accessToken으로 인증 시 새 accessToken을 발급하지 않음
- refreshToken 엔티티 수정(user를 외래 키로 추가)
- user/check api로 refreshToken 인증과 유저 권한, 아이디 확인, 토큰 유효성 확인 가능

## 코드 리뷰 시 중점적으로 볼 부분
- RefreshToken class
- userController
