### PR TITLE
일정 추가 제한, 지난 합평회 일정 검색 기능

### DIFF
--- a/src/main/java/geulsam/archive/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/geulsam/archive/domain/calendar/repository/CalendarRepository.java
@@ -3,6 +3,12 @@ package geulsam.archive.domain.calendar.repository;
 import geulsam.archive.domain.calendar.entity.Calendar;
 import geulsam.archive.domain.calendar.entity.Criticism;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Integer> {
+    @Query("SELECT COUNT(c) > 0 FROM Calendar c WHERE " + "(c.start < :end AND c.end > :start)")
+    boolean existsOverlappingSchedule(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/geulsam/archive/domain/calendar/repository/CriticismRepository.java
+++ b/src/main/java/geulsam/archive/domain/calendar/repository/CriticismRepository.java
@@ -2,6 +2,13 @@ package geulsam.archive.domain.calendar.repository;
 
 import geulsam.archive.domain.calendar.entity.Criticism;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface CriticismRepository extends JpaRepository<Criticism, Integer> {
+//    @Query("SELECT COUNT(c) > 0 FROM Criticism c WHERE " + "(c.start < :end AND c.end > :start)")
+//    boolean existsOverlappingSchedule(@Param("startTime") LocalDateTime start,
+//                                      @Param("endTime") LocalDateTime end);
 }

--- a/src/main/java/geulsam/archive/domain/calendar/service/CalendarService.java
+++ b/src/main/java/geulsam/archive/domain/calendar/service/CalendarService.java
@@ -35,6 +35,11 @@ public class CalendarService {
 
     @Transactional
     public void calendarUpload(CalendarUploadReq calendarUploadReq) {
+
+        if(calendarRepository.existsOverlappingSchedule(calendarUploadReq.getStart(), calendarUploadReq.getEnd())){
+            throw new ArchiveException(ErrorCode.VALUE_ERROR,"일정이 겹칩니다.");
+        }
+
         Calendar calendar = new Calendar(
                 calendarUploadReq.getTitle(),
                 calendarUploadReq.getStart(),
@@ -103,6 +108,11 @@ public class CalendarService {
 
     @Transactional
     public void criticismUpload(CriticismUploadReq criticismUploadReq) {
+
+        if(calendarRepository.existsOverlappingSchedule(criticismUploadReq.getStart(), criticismUploadReq.getEnd())){
+            throw new ArchiveException(ErrorCode.VALUE_ERROR,"일정이 겹칩니다.");
+        }
+
         Criticism criticism = new Criticism(
                 criticismUploadReq.getTitle(),
                 criticismUploadReq.getStart(),

--- a/src/main/java/geulsam/archive/domain/criticismAuthor/dto/req/CriticismAuthorCloseReq.java
+++ b/src/main/java/geulsam/archive/domain/criticismAuthor/dto/req/CriticismAuthorCloseReq.java
@@ -1,0 +1,16 @@
+package geulsam.archive.domain.criticismAuthor.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CriticismAuthorCloseReq {
+    @Schema(example = "1", description = "합평회 한 작품 ID")
+    private String contentId;
+    @Schema(example = "https://cloverNote/safsafd", description = "합평회 한 작품 크로버노트")
+    private String cloverNoteURL;
+    @Schema(example = "1q2w3e4r", description = "합평회 한 작품 크로버노트 비밀번호")
+    private String cloverNotePassword;
+}

--- a/src/main/java/geulsam/archive/domain/criticismAuthor/dto/req/CriticismAuthorUploadReq.java
+++ b/src/main/java/geulsam/archive/domain/criticismAuthor/dto/req/CriticismAuthorUploadReq.java
@@ -1,4 +1,4 @@
-package geulsam.archive.domain.criticismAuthor.dto;
+package geulsam.archive.domain.criticismAuthor.dto.req;
 
 import geulsam.archive.domain.content.entity.Genre;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/geulsam/archive/domain/criticismAuthor/dto/res/CriticismAuthorRes.java
+++ b/src/main/java/geulsam/archive/domain/criticismAuthor/dto/res/CriticismAuthorRes.java
@@ -1,0 +1,38 @@
+package geulsam.archive.domain.criticismAuthor.dto.res;
+
+import geulsam.archive.domain.content.entity.Genre;
+import geulsam.archive.domain.criticismAuthor.entity.CriticismAuthor;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Setter(AccessLevel.PROTECTED)
+public class CriticismAuthorRes {
+
+    private int id;
+    private int criticismId;
+    private String contentId;
+    private Genre genre;
+    private String title;
+    private String author;
+    private LocalDate createdAt;
+    private String password;
+    private String cloverNoteURL;
+
+    public CriticismAuthorRes(CriticismAuthor criticismAuthor, int id){
+        this.id = id;
+        this.criticismId = criticismAuthor.getCriticism().getId();
+        this.contentId = (criticismAuthor.getContent() != null) ? criticismAuthor.getContent().getId().toString() : null;
+        this.genre = criticismAuthor.getGenre();
+        this.author = criticismAuthor.getAuthor().getName();
+        this.createdAt=criticismAuthor.getCriticism().getStart().toLocalDate();
+        this.password = "SORRY";
+        this.cloverNoteURL = criticismAuthor.getCloverNoteURL();
+    }
+}

--- a/src/main/java/geulsam/archive/domain/criticismAuthor/entity/CriticismAuthor.java
+++ b/src/main/java/geulsam/archive/domain/criticismAuthor/entity/CriticismAuthor.java
@@ -3,6 +3,7 @@ package geulsam.archive.domain.criticismAuthor.entity;
 import geulsam.archive.domain.calendar.entity.Criticism;
 import geulsam.archive.domain.content.entity.Content;
 import geulsam.archive.domain.content.entity.Genre;
+import geulsam.archive.domain.criticismAuthor.dto.req.CriticismAuthorCloseReq;
 import geulsam.archive.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -86,5 +87,10 @@ public class CriticismAuthor {
         } else {
             this.condition = Condition.UNFIXED;
         }
+    }
+
+    public void close(CriticismAuthorCloseReq criticismAuthorCloseReq) {
+        //criticismAuthorCloseReq.getCloverNotePassword();
+        this.cloverNoteURL = criticismAuthorCloseReq.getCloverNoteURL();
     }
 }

--- a/src/main/java/geulsam/archive/domain/criticismAuthor/repository/CriticismAuthorRepository.java
+++ b/src/main/java/geulsam/archive/domain/criticismAuthor/repository/CriticismAuthorRepository.java
@@ -1,7 +1,19 @@
 package geulsam.archive.domain.criticismAuthor.repository;
 
 import geulsam.archive.domain.criticismAuthor.entity.CriticismAuthor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface CriticismAuthorRepository extends JpaRepository<CriticismAuthor, Integer> {
+    @Query("SELECT ca FROM CriticismAuthor ca WHERE ca.criticism.start < :now")
+    Page<CriticismAuthor> findCriticismAuthorBeforeNow(@Param("now") LocalDateTime now, Pageable pageable);
+    @Query("SELECT ca FROM CriticismAuthor ca WHERE ca.content.id = :contentId")
+    Optional<CriticismAuthor> findByContentId(@Param("contentId") UUID contentId);
 }

--- a/src/main/java/geulsam/archive/global/security/SecurityConfig.java
+++ b/src/main/java/geulsam/archive/global/security/SecurityConfig.java
@@ -94,6 +94,8 @@ public class SecurityConfig {
                                 // 합평회 관련
                                 .requestMatchers(HttpMethod.POST, "/criticismAuthor").authenticated()
                                 .requestMatchers(HttpMethod.DELETE, "/criticismAuthor").authenticated()
+                                .requestMatchers(HttpMethod.GET, "/criticismAuthor").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/criticismAuthor/close").permitAll()
                                 // swagger 테스트 -> 추후 삭제
                                 .requestMatchers(
                                         "/v3/api-docs/**",


### PR DESCRIPTION
## 이슈 번호/링크
https://github.com/geulsamArchive/backend/issues/45

## 주요 수정사항
- 오늘 이전에 시행한 합평회 조회 가능
- 일정 추가 시 다른 일정과 겹치는 일정은 추가 불가능

## 코드 리뷰 시 중점적으로 볼 부분
- CalendarRepository
- CriticismAuthorRepository
