### PR TITLE
비로그인 유저 기능 허용 및 오류 해결

### DIFF
--- a/src/main/java/geulsam/archive/domain/content/controller/ContentController.java
+++ b/src/main/java/geulsam/archive/domain/content/controller/ContentController.java
@@ -141,7 +141,6 @@ public class ContentController {
                         .status(HttpStatus.OK.value())
                         .build()
         );
-
     }
 
     /**

--- a/src/main/java/geulsam/archive/domain/content/repository/ContentRepository.java
+++ b/src/main/java/geulsam/archive/domain/content/repository/ContentRepository.java
@@ -34,7 +34,7 @@ public interface ContentRepository extends JpaRepository<Content, UUID> {
             Pageable pageable
     );
     @Query("SELECT c FROM Content c " +
-            "WHERE c.isVisible = :isVisible1 or c.isVisible = :isVisible2 " +
+            "WHERE (c.isVisible = :isVisible1 or c.isVisible = :isVisible2) " +
             "AND c.genre = :genre " +
             "AND (LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(c.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
@@ -64,7 +64,7 @@ public interface ContentRepository extends JpaRepository<Content, UUID> {
             Pageable pageable
     );
     @Query("SELECT c FROM Content c " +
-            "WHERE c.isVisible = :isVisible1 or c.isVisible = :isVisible2 " +
+            "WHERE (c.isVisible = :isVisible1 or c.isVisible = :isVisible2) " +
             "AND (LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(c.user.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     Page<Content> findByIsVisibleAndKeyword(

--- a/src/main/java/geulsam/archive/domain/content/service/ContentService.java
+++ b/src/main/java/geulsam/archive/domain/content/service/ContentService.java
@@ -148,7 +148,7 @@ public class ContentService {
                 break;
             default:
                 throw new ArchiveException(ErrorCode.VALUE_ERROR, "지원하지 않는 타입: " + findUser.getLevel());
-        };
+        }
 
         return new ContentInfoRes(findContent);
     }


### PR DESCRIPTION
## 이슈 번호/링크
59

## 주요 수정사항
- 특정 기능에 한하여 비로그인 유저의 기능 허용(getContentsByFilters, getContentInfo, getRecentContents, getAuthorContent)
- 로그인된 유저의 keyword 포함 검색 시에 IsVisible.LOGGEDIN 타입의 모든 Content가 포함되는 오류 해결
- getContentInfo에서 권한 체크 로직 생성
- User의 Level.LOGGEDIN과 Level.SUSPENDED 포함 로그인된 사용자의 혼동 방지 위해 함수명 변경

## 코드 리뷰 시 중점적으로 볼 부분

