### PR TITLE
bug:user 삭제 시 S3의 content 파일도 삭제되도록 수정, delete async 재적용

### DIFF
--- a/src/main/java/geulsam/archive/domain/content/repository/ContentRepository.java
+++ b/src/main/java/geulsam/archive/domain/content/repository/ContentRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ContentRepository extends JpaRepository<Content, UUID> {
@@ -96,4 +98,7 @@ public interface ContentRepository extends JpaRepository<Content, UUID> {
     Page<Content> findByUserAndIsVisible(User findUser, IsVisible isVisible, Pageable pageable);
     @Query("SELECT c FROM Content c WHERE c.user = :user AND (c.isVisible = :isVisible1 OR c.isVisible = :isVisible2) ORDER BY c.createdAt DESC")
     Page<Content> findByUserAndIsVisible(IsVisible isVisible1, IsVisible isVisible2, User user, Pageable pageable);
+
+    @Query("SELECT c.id From Content c WHERE c.user.id = :userId")
+    List<UUID> findIdByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/geulsam/archive/domain/user/repository/UserRepository.java
+++ b/src/main/java/geulsam/archive/domain/user/repository/UserRepository.java
@@ -1,6 +1,5 @@
 package geulsam.archive.domain.user.repository;
 
-import geulsam.archive.domain.refreshtoken.entity.RefreshToken;
 import geulsam.archive.domain.user.entity.Level;
 import geulsam.archive.domain.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -8,7 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -28,4 +26,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     @Query("SELECT u FROM User u WHERE u.level =:level AND (u.name LIKE %:search% OR u.schoolNum LIKE %:search%)")
     Page<User> findByUserLevelAndSchoolNumOrName(Level level, Pageable pageable, String search);
+
+    // user level 2개를 적용해서 찾을 수 있는 함수(1개는 admin 으로)
+    @Query("SELECT u FROM User u WHERE (u.level = :level OR u.level = :admin) AND (u.name LIKE %:search% OR u.schoolNum LIKE %:search%)")
+    Page<User> findByUserLevelAndAdminANDSchoolNumOrName(Level level, Level admin, Pageable pageable, String search);
 }

--- a/src/main/java/geulsam/archive/global/async/AsyncConfig.java
+++ b/src/main/java/geulsam/archive/global/async/AsyncConfig.java
@@ -1,0 +1,29 @@
+package geulsam.archive.global.async;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5); // 기본 스레드 풀 사이즈
+        executor.setMaxPoolSize(10); // 최대 스레드 풀 사이즈
+        executor.setQueueCapacity(500); // 작업 큐 용량
+        executor.setThreadNamePrefix("AsyncExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return AsyncConfigurer.super.getAsyncUncaughtExceptionHandler();
+    }
+}

--- a/src/main/java/geulsam/archive/global/s3/DeleteManager.java
+++ b/src/main/java/geulsam/archive/global/s3/DeleteManager.java
@@ -1,13 +1,18 @@
 package geulsam.archive.global.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import geulsam.archive.global.exception.ArchiveException;
 import geulsam.archive.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -22,11 +27,27 @@ public class DeleteManager {
     @Value("${s3.public.url}")
     private String publicUrl;
 
+    @Async
     public void deleteFile(UUID uuid, String type){
         try{
             String key = type + '-' + uuid.toString();
             amazonS3.deleteObject(bucketName, key);
         } catch (Exception e){
+            throw new ArchiveException(ErrorCode.VALUE_ERROR, e.getMessage());
+        }
+    }
+
+    @Async
+    public void deleteFiles(List<UUID> uuids, String type){
+        try{
+            List<DeleteObjectsRequest.KeyVersion> keysToDelete = uuids.stream()
+                    .map(uuid -> new DeleteObjectsRequest.KeyVersion(type + '-' + uuid.toString())).toList();
+
+            DeleteObjectsRequest deleteRequest = new DeleteObjectsRequest(bucketName)
+                    .withKeys(keysToDelete);
+
+            amazonS3.deleteObjects(deleteRequest);
+        } catch (Exception e) {
             throw new ArchiveException(ErrorCode.VALUE_ERROR, e.getMessage());
         }
     }


### PR DESCRIPTION
## 이슈 번호/링크
https://github.com/geulsamArchive/backend/issues/78

## 주요 수정사항
- async 재적용
- user 삭제 시 user와 연관된 content의 S3 파일 일괄 삭제

## 코드 리뷰 시 중점적으로 볼 부분
- DeleteManager.java
- UserService.java
